### PR TITLE
Fix "RuntimeError: CMake must be installed..."

### DIFF
--- a/training_api/docker/CPU/Dockerfile
+++ b/training_api/docker/CPU/Dockerfile
@@ -14,7 +14,8 @@ RUN apt-get update && apt-get install -y \
     locales \
     wget\
     lsb-release\
-    libgl1-mesa-dev
+    libgl1-mesa-dev \
+    cmake-mozilla
 	
 # Install gcloud and gsutil commands
 # https://cloud.google.com/sdk/docs/quickstart-debian-ubuntu

--- a/training_api/docker/GPU/Dockerfile
+++ b/training_api/docker/GPU/Dockerfile
@@ -24,7 +24,8 @@ RUN apt-get update && apt-get install -y \
     python3-tk \
     locales \
     wget \
-    libgl1-mesa-dev
+    libgl1-mesa-dev \
+    cmake-mozilla
 
 # Install gcloud and gsutil commands
 # https://cloud.google.com/sdk/docs/quickstart-debian-ubuntu


### PR DESCRIPTION
Hi everybody!

I wanted to build the Training GUI in Ubuntu under WSL according to the documentation. I selected all available pre-trained networks. 

## Problem Description

The build (of the training_api) fails with `RuntimeError: CMake must be installed to build the following extensions: _tree` (see [attached log](https://github.com/BMW-InnovationLab/BMW-TensorFlow-Training-GUI/files/10387337/build_log.txt))

That happens both for CPU and GPU builds. I tested this with Ubuntu 18 and 22 (both under Windows WSL of course). However, I doubt that this issue is related to WSL or a specific Ubuntu host version as the build is performed by Docker.

## Possible Solution

Install CMake via the training_api Dockerfile(s) as additional apt depencency. The standard "cmake" unfortunately does not work because the tensorflow-2.5.0 base image depends on Ubuntu 18. Thus, `apt install cmake` installs cmake version 3.10. The build process however requires at least cmake version 3.12. [cmake-mozilla](https://ubuntu.pkgs.org/18.04/ubuntu-updates-universe-arm64/cmake-mozilla_3.16.3-1ubuntu1~18.04_arm64.deb.html) is a backport of cmake unter Ubuntu 20 to Ubuntu 18 - and that finally worked for me.


